### PR TITLE
live reload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,45 @@
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 var inject = require('gulp-inject');
+var nodemon = require('gulp-nodemon');
+var bs = require('browser-sync').create();
 var angularFilesort = require('gulp-angular-filesort');
 
 gulp.task('default', ['index']);
 
 gulp.task('index', function () {
     var target = gulp.src('./src/index.html');
-    var sources = gulp.src(['./src/selfStarted/*.js','./src/selfStarted/features/**/*.js']).pipe(angularFilesort());
+    var sources = gulp.src(['./src/selfStarted/*.js', './src/selfStarted/features/**/*.js']).pipe(angularFilesort());
 
     return target.pipe(inject(sources, { ignorePath: 'src/', addRootSlash: false }))
         .pipe(gulp.dest('./src'));
+});
+
+gulp.task('browser-sync', ['nodemon'], function () {
+    bs.init(null, {
+        proxy: 'http://localhost:3000',
+        port: 4000
+    });
+});
+
+
+
+gulp.task('nodemon', function (cb) {
+
+    var started = false;
+
+    return nodemon({
+        script: 'server.js'
+    }).on('start', function () {
+        // to avoid nodemon being started multiple times
+        // thanks @matthisk
+        if (!started) {
+            cb();
+            started = true;
+        }
+    });
+});
+
+gulp.task('start', ['browser-sync'], function () {
+    gulp.watch("./src/selfStarted/features/**/*.html").on('change', bs.reload);
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "private": true,
   "scripts": {
-    "start": "nodemon server.js",
+    "start": "gulp start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -35,6 +35,7 @@
     "morgan": "1.8.1"
   },
   "devDependencies": {
+    "browser-sync": "^2.18.8",
     "gulp": "^3.9.1",
     "gulp-angular-filesort": "^1.1.1",
     "gulp-inject": "^4.2.0",

--- a/src/selfStarted/features/landingPage/landingPage.html
+++ b/src/selfStarted/features/landingPage/landingPage.html
@@ -21,7 +21,7 @@
         <tr>
             <td>Jonathan</td>
             <td>Lollipop</td>
-            <td>$7.00</td>
+            <td>$200.00</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Added live reload for html editing in gulp.  Uses Browser sync and gulp nodemon for restarting on saved changes.  Changes port number from 3000 to 4000 but still uses api on node server on port 3000