### PR TITLE
added route for user to find assigned projects

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -86,6 +86,7 @@ router.get('/projects/searchProjects?', function(req, res, next) {
     Projects.find(req.query)
         .populate('_primaryProjectOwner')
         .populate('_usersAssigned')
+        .populate('_usersInvited')
         .exec(function(error, projectsData) {
             if (error) return error;
             res.json(projectsData);
@@ -102,11 +103,27 @@ router.get('/projects/searchPersonalProjects?', function(req, res, next) {
     Projects.find(req.query)
         .populate('_primaryProjectOwner')
         .populate('_usersAssigned')
+        .populate('_usersInvited')
         .exec(function(error, personalProjectsData) {
             if (error) return error;
             res.json(personalProjectsData);
         });
+});
 
+// searchAssignedProjects route for user to find projects they're assigned
+// to but do not own. THIS IS THE REASON WHY WE DO NOT PUT THE PROJECT OWNER
+// IN THE ASSIGNED USERS FIELD. req.query needs to send the user's objectID
+// as _usersAssigned from the front end
+router.get('/projects/searchAssignedProjects?', function(req, res, next) {
+
+    Projects.find(req.query)
+        .populate('_primaryProjectOwner')
+        .populate('_usersAssigned')
+        .populate('_usersInvited')
+        .exec(function(error, assignedProjectsData) {
+            if (error) return error;
+            res.json(assignedProjectsData);
+        });
 });
 
 module.exports = router;


### PR DESCRIPTION
Added get route /projects/searchAssignedProjects so user can get all the projects to which they are assigned but are not the project owner.