### PR TITLE
added route to deny a project join request

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -161,4 +161,27 @@ router.post('/projects/joinProject', function(req, res, next) {
     });
 });
 
+// denyProjectJoin is a post route for denying a user who has requested
+// to join a project. The post request needs to send the _id of the project
+// itself and also send the id of the user who had requested to join as 
+// _usersInvited
+router.post('/projects/denyProjectJoin', function(req, res, next) {
+    console.log('updating project');
+    console.log(req.body);
+
+    Projects.findByIdAndUpdate(req.body._id, {
+        $pull: {_usersInvited: req.body._usersInvited}
+    }, {
+        'new': true
+        })
+    .exec(function(err, projectData) {
+        if (err) {
+            console.log(err);
+            res.send(err);
+        } else {
+            res.send(projectData);
+        }
+    });
+});
+
 module.exports = router;


### PR DESCRIPTION
Created a POST route /projects/denyProjectJoin for project owner to deny a user who has requested to join their project. The post request needs to send the _id of the project itself and also send the id of the user who had requested to join as _usersInvited.