### PR TITLE
added accept project join route

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -184,4 +184,28 @@ router.post('/projects/denyProjectJoin', function(req, res, next) {
     });
 });
 
+// acceptProjectJoin is a post route for accepting a user who has requested
+// to join a project. The post request needs to send the _id of the project
+// itself and also send the id of the user who had requested to join as 
+// _usersInvited
+router.post('/projects/acceptProjectJoin', function(req, res, next) {
+    console.log('updating project');
+    console.log(req.body);
+
+    Projects.findByIdAndUpdate(req.body._id, {
+        $pull: {_usersInvited: req.body._usersInvited},
+        $push: {_usersInvited: req.body._usersAssigned} 
+    }, {
+        'new': true
+        })
+    .exec(function(err, projectData) {
+        if (err) {
+            console.log(err);
+            res.send(err);
+        } else {
+            res.send(projectData);
+        }
+    });
+});
+
 module.exports = router;


### PR DESCRIPTION
Added POST route /projects/acceptProjectJoin for a user to who owns a project to accept someone who has requested to join their project. The post request needs to send the _id of the project itself and also send the id of the user who had requested to join as _usersInvited.