### PR TITLE
fixed project routes for accepting

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -214,7 +214,7 @@ router.post('/projects/acceptProjectJoin', function(req, res, next) {
 
     Projects.findByIdAndUpdate(req.body._id, {
         $pull: {_usersRequesting: req.body._usersRequesting},
-        $push: {_usersRequesting: req.body._usersAssigned} 
+        $push: {_usersAssigned: req.body._usersRequesting} 
     }, {
         'new': true
         })
@@ -283,7 +283,7 @@ router.post('/projects/acceptProjectInvite', function(req, res, next) {
 
     Projects.findByIdAndUpdate(req.body._id, {
         $pull: {_usersInvited: req.body._usersInvited},
-        $push: {_usersInvited: req.body._usersAssigned} 
+        $push: {_usersAssigned: req.body._usersInvited} 
     }, {
         'new': true
         })


### PR DESCRIPTION
Fixed the /projects/acceptProjectJoin and /projects/acceptProjectInvite so that the passed in parameter was being passed to the correct key. Original code had the assignment reversed by mistake.