### PR TITLE
fixed push to addToSet operator for projects routes

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -165,7 +165,7 @@ router.post('/projects/joinProject', function(req, res, next) {
     console.log(req.body);
 
     Projects.findByIdAndUpdate(req.body._id, {
-        $push: {_usersRequesting: req.body._usersRequesting}
+        $addToSet: {_usersRequesting: req.body._usersRequesting}
     }, {
         'new': true
         })
@@ -212,7 +212,7 @@ router.post('/projects/acceptProjectJoin', function(req, res, next) {
 
     Projects.findByIdAndUpdate(req.body._id, {
         $pull: {_usersRequesting: req.body._usersRequesting},
-        $push: {_usersAssigned: req.body._usersRequesting}
+        $addToSet: {_usersAssigned: req.body._usersRequesting}
     }, {
         'new': true
         })
@@ -234,7 +234,7 @@ router.post('/projects/inviteProject', function(req, res, next) {
     console.log(req.body);
 
     Projects.findByIdAndUpdate(req.body._id, {
-        $push: {_usersInvited: req.body._usersInvited}
+        $addToSet: {_usersInvited: req.body._usersInvited}
     }, {
         'new': true
         })
@@ -281,7 +281,7 @@ router.post('/projects/acceptProjectInvite', function(req, res, next) {
 
     Projects.findByIdAndUpdate(req.body._id, {
         $pull: {_usersInvited: req.body._usersInvited},
-        $push: {_usersAssigned: req.body._usersInvited} 
+        $addToSet: {_usersAssigned: req.body._usersInvited} 
     }, {
         'new': true
         })


### PR DESCRIPTION
Change projects routes for user addition in various arrays from $push to $addToSet. Push will push in a user multiple times if they make multiple requests. However, $addToSet will only push to array if the value doesn't already exist. This will prevent users from making multiple join requests. However, you could still have a situation where a user has joined already and is in the added related array, then makes a new join request and is now also in the request related array. In that case if the project owner accepts, it will have the effect of removing them from the request related array and not adding them again to the added related array. If the project owner denies then it will just clear them out of the request related array. This works, but probably will need some cleanup at some point so someone already joined and added cannot make a request to join. Maybe on the front end we want to prevent display of projects in a search taht they're already a member of? Or perhaps not offer them the button to join if they're already a member? TBD.