### PR TITLE
project name no longer unique field

### DIFF
--- a/api/models/projects.model.js
+++ b/api/models/projects.model.js
@@ -20,8 +20,7 @@ var ProjectsSchema = new Schema({
 	projectName: {
 		type: String,
 		required: true,
-		trim: true,
-		unique: true
+		trim: true
 	},
 
 	// Save a lowercase version of the project name. Needed for when we search
@@ -31,8 +30,7 @@ var ProjectsSchema = new Schema({
 	projectNameLowerCase: {
 		type: String,
 		required: true,
-		trim: true,
-		unique: true
+		trim: true
 	},
 
 	// projectDescription is a text description entered by the project owner,


### PR DESCRIPTION
projectName and projectNameLowerCase are no longer "unique: true" fields in the Projects model, as per group agreement during discussion 03/27/17. 