### PR TITLE
updated projects routes

### DIFF
--- a/api/routes/projects.api.js
+++ b/api/routes/projects.api.js
@@ -21,8 +21,6 @@ router.post('/projects/newProject', function (req, res, next) {
         projectCountry: req.body.projectCountry,
         projectState: req.body.projectState,
         projectCity: req.body.projectCity,
-        projectLocation: req.body.projectLocation,
-        projectLocationLowerCase: req.body.projectLocationLowerCase,
         projectCategoryByCollege: req.body.projectCategoryByCollege,
         projectCategoryByProgram: req.body.projectCategoryByProgram,
         otherSkillsDesired: req.body.otherSkillsDesired,


### PR DESCRIPTION
Fixed /projects/newProject route to remove the old projectLocation and projectLocationLowerCase fields that were left behind in last commit when location was changed to the three fields of projectCountry, projectState and projectCity.