### PR TITLE
Profile edit changes

### DIFF
--- a/src/selfStarted/features/profilePage/profilePage.controller.js
+++ b/src/selfStarted/features/profilePage/profilePage.controller.js
@@ -5,7 +5,9 @@ angular
 function ProfilePageCtrl($scope, localStorageService, UsersService, CollegeService, UserLocation) {
     var vm = this;
     var college = CollegeService;
+    var userLocation = UserLocation;
     var mainCollegeField = Object.keys(college);
+    var country = Object.keys(userLocation);
     var users = UsersService;
     var userID = {_id: getItem('userDBid')};
     vm.user = {};
@@ -15,41 +17,15 @@ function ProfilePageCtrl($scope, localStorageService, UsersService, CollegeServi
     vm.subcolleges = [];
     vm.changeSubCollege = changeSubCollege;
 
+    //location drop menu init
+    vm.userCountries = country;
+    vm.changeState = changeState;
+    vm.changeCity = changeCity;
+
     //edit/save button configs
     vm.edit = false;
     vm.toggleEdit = toggleEdit;
     vm.saveChanges = saveChanges;
-    
-
-    vm.changeState = changeState;
-    vm.changeCity = changeCity;
-
-    var userLocation = UserLocation;
-
-    var country = Object.keys(userLocation);
-
-    $scope.countries = country;
-
-    function changeState(){
-
-        let key = vm.countryUser;
-
-        let userCountry = Object.keys(userLocation[key]);
-
-        $scope.states = userCountry;
-
-    }
-
-    function changeCity() {
-
-        let keyCountry = vm.countryUser;
-        let keyState = vm.stateUser;
-
-        let userState = userLocation[keyCountry][keyState];
-
-        $scope.cities = userState
-
-    }
 
     users.getUsers(userID, function (err, response) {
         if (err) console.error(err);
@@ -74,7 +50,7 @@ function ProfilePageCtrl($scope, localStorageService, UsersService, CollegeServi
     function saveChanges() {
  // userCountry, userState, userCityArea
 
-        let theSkills = [vm.skills1,vm.skills2,vm.skills3,vm.skills4]
+        let theSkills = [vm.skills1,vm.skills2,vm.skills3,vm.skills4];
 
         let skillsHolder = [];
 
@@ -93,14 +69,14 @@ function ProfilePageCtrl($scope, localStorageService, UsersService, CollegeServi
 
         var updatedInfo = {
             _id: userID._id,
-            userCountry : vm.countryUser,
-            userState : vm.stateUser,
-            userCity : vm.cityUser,
+            userCountry : vm.user.userCountry,
+            userState : vm.user.userState,
+            userCity : vm.user.userCity,
             willDoRemoteProjects: vm.user.remote,
             willDoLocalProjects: vm.user.local,
             aboutMe: vm.user.description,
             userSchoolName: vm.user.schoolName,
-            additionalSkills: skillsHolder,
+            additionalSkills: vm.user.additionalSkills,
             defaultSkillByCollege: vm.user.college,
             defaultSkillByProgram: vm.user.major
         };
@@ -112,6 +88,27 @@ function ProfilePageCtrl($scope, localStorageService, UsersService, CollegeServi
             users.updateUser(updatedInfo);
             vm.edit = false;
         }
+    }
+
+    function changeState() {
+
+        var key = vm.country;
+        vm.user.userCountry = key;
+        var userCountry = Object.keys(userLocation[key]);
+        var userState = userCountry;
+        vm.userStates = userState;
+    }
+
+    function changeCity() {
+
+        let keyCountry = vm.country;
+        let keyState = vm.state;
+        vm.user.userState = vm.state;
+        let userState = userLocation[keyCountry][keyState];
+
+        vm.userCities = userState;
+        vm.user.userCity = vm.city;
+
     }
 
     function changeSubCollege() {
@@ -127,7 +124,6 @@ function setCurrentUser(user) {
     return {
         firstName: user.firstName,
         lastName: user.lastName,
-        location: user.userLocation,
         userCountry: user.userCountry,
         userState: user.userState,
         userCity: user.userCity,

--- a/src/selfStarted/features/profilePage/profilePage.html
+++ b/src/selfStarted/features/profilePage/profilePage.html
@@ -56,9 +56,9 @@
                                                 <select 
 
                                                   class="styled-select dropBoxClear semi-square" 
-                                                  data-ng-model="ProfilePageVM.countryUser" 
+                                                  data-ng-model="ProfilePageVM.country" 
                                                   data-ng-change="ProfilePageVM.changeState()" 
-                                                  data-ng-options="country as country for country in countries">
+                                                  data-ng-options="country for country in ProfilePageVM.userCountries">
 
                                                     <option value="">Country</option>
 
@@ -67,9 +67,9 @@
                                                 <select 
 
                                                   class="styled-select dropBoxClear semi-square" 
-                                                  data-ng-model="ProfilePageVM.stateUser"
+                                                  data-ng-model="ProfilePageVM.state"
                                                   data-ng-change="ProfilePageVM.changeCity()" 
-                                                  data-ng-options="state for state in states">
+                                                  data-ng-options="state for state in ProfilePageVM.userStates">
 
                                                     <option value="">State</option>
 
@@ -78,8 +78,9 @@
                                                 <select 
 
                                                   class="styled-select dropBoxClear semi-square" 
-                                                  data-ng-model="ProfilePageVM.cityUser" 
-                                                  data-ng-options="city for city in cities">
+                                                  data-ng-model="ProfilePageVM.city"
+                                                  data-ng-change="ProfilePageVM.changeCity()"
+                                                  data-ng-options="city for city in ProfilePageVM.userCities">
 
                                                     <option value="">Major City</option>
 
@@ -176,7 +177,7 @@
                                                    aria-placeholder="Skills needed" 
                                                    type="text" 
                                                    class="form-control" 
-                                                   ng-model="ProfilePageVM.skills1"/>
+                                                   ng-model="ProfilePageVM.user.additionalSkills[0]"/>
 
                                                </div>
 
@@ -188,7 +189,7 @@
                                                    aria-placeholder="Skills needed" 
                                                    type="text" 
                                                    class="form-control" 
-                                                   ng-model="ProfilePageVM.skills2"/>
+                                                   ng-model="ProfilePageVM.user.additionalSkills[1]"/>
 
                                                </div>
 
@@ -200,7 +201,7 @@
                                                     aria-placeholder="Skills needed" 
                                                     type="text" 
                                                     class="form-control" 
-                                                     ng-model="ProfilePageVM.skills3"/>
+                                                     ng-model="ProfilePageVM.user.additionalSkills[2]"/>
 
                                                </div>
 
@@ -212,7 +213,7 @@
                                                    aria-placeholder="Skills needed" 
                                                    type="text" 
                                                    class="form-control" 
-                                                    ng-model="ProfilePageVM.skills4"/>
+                                                    ng-model="ProfilePageVM.user.additionalSkills[3]"/>
 
                                                </div> 
 


### PR DESCRIPTION
Ok profile page should now prePopulate with all its previous data already pre populating the fields. The user should also be able to edit a field without it erasing any other previous data, so they don't have to re-enter all their information for every update.  So now skills and location should always just have what it previously did when a user hits edit and save. (man what a pain in the ass that was)